### PR TITLE
Exclude ".test" files from store folder

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -36,7 +36,7 @@ export const register = {
   vuexStores ({ fullStoreDir, exclude = [] }) {
     const imports = [], aliases = [], store = { modules: {} }
     let rootStore
-    const pattern = `${fullStoreDir}/**/*+(.mjs|.ts|.js)`
+    const pattern = `${fullStoreDir}/**/!(*.test)*+(.mjs|.ts|.js)`
     const storeDefinitionFiles = (glob.sync(pattern))
       .filter(file => ! exclude.includes(file))
 


### PR DESCRIPTION
## Exclude `.test` files from stores load :test_tube: 

Many projects use `.test.{js|ts}` files on the store folder, I made a small change to exclude those files from the initial store search pattern.

Because test files does not have the same syntax as a store, the import will fail, excluding them will fix this issue.

### Without `.test` exclusion :x: 
![image](https://user-images.githubusercontent.com/54317276/229777039-7e705c07-8a2f-4d94-ac96-037510bb4331.png)

### With `.test` exclusion :heavy_check_mark: 
**Warn disappeared**, stores correctly loaded!
