### PR TITLE
Create a unique store per page render

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,9 +2,8 @@ import { createStore } from 'vuex'
 import { defineNuxtPlugin } from '#app'
 import VuexStore from '#build/vuexStore.js'
 
-const store = createStore(VuexStore)
-
 export default defineNuxtPlugin((nuxtApp) => {
+  const store = createStore(VuexStore)
   nuxtApp.vueApp.use(store)
 
   if (process.server) {


### PR DESCRIPTION
Hi!

We were trying your module as we might be interested in using it for a nuxt2 to nuxt3 migration. In the course of trying it out, we might have found a little bug. This PR should fix it.

Previous to the change there is one unique store that is global to all page renders. With the change there is one store per page render - as is the normal behavior of vuex in nuxt2.

Thank you for your work!
Fabian