### PR TITLE
Remove the ts extesions as well

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -56,7 +56,7 @@ export const register = {
         rootStore = alias
       } else {
         // Modules
-        const namespace = path.replace(/\.(js|mjs)$/, '')
+        const namespace = path.replace(/\.(js|mjs|ts)$/, '')
         const namespaces = namespace.split('/')
         addModule(store, namespaces, alias)
       }


### PR DESCRIPTION
Getting an error when defining vuex with TypeScript.
So remove the ts extensions as well.

```
~/projects/nuxt-starter-kh6rmq 5s
❯ npm run build

> build
> nuxt build

[18:57:25] Nuxi 3.6.2
[18:57:26] Nuxt 3.6.2 with Nitro 2.5.2
[18:57:31] ℹ Building client...
[18:57:31] ℹ vite v4.3.9 building for production...
[18:57:32] ℹ ✓ 24 modules transformed.
[18:57:32] ℹ ✓ built in 395ms

[18:57:32]  ERROR  Unexpected token
file: virtual:nuxt:/home/projects/nuxt-starter-kh6rmq/.nuxt/vuexStore.js:6:11
4: const VuexStore = {
5:   modules: {
6:       dummy.ts: {
              ^
7:         ...dummyVuexStore,
8:         namespaced: true,


[18:57:32]  ERROR  Unexpected token

  at error (node_modules/rollup/dist/es/shared/node-entry.js:2270:30)
  at Module.error (node_modules/rollup/dist/es/shared/node-entry.js:13609:16)
  at Module.tryParse (node_modules/rollup/dist/es/shared/node-entry.js:14335:25)
  at Module.setSource (node_modules/rollup/dist/es/shared/node-entry.js:13936:39)
  at ModuleLoader.addModuleSource (node_modules/rollup/dist/es/shared/node-entry.js:24464:20)


~/projects/nuxt-starter-kh6rmq 7s
```

https://stackblitz.com/edit/nuxt-starter-kh6rmq?file=package.json