### PR TITLE
Fix Windows Paths

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -89,7 +89,11 @@ export default defineNuxtModule({
       exclude = [],
     } = moduleOptions
 
-    const fullStoreDir = resolve(nuxt.options.srcDir, storeDir)
+	let fullStoreDir = resolve(nuxt.options.srcDir, storeDir)
+	if (process.platform === 'win32') {
+		fullStoreDir = fullStoreDir.replace(/\\/g,'/')
+	}
+
     if (existsSync(fullStoreDir)) {
       const { resolve } = createResolver(import.meta.url)
       register.vuexStores({ fullStoreDir, exclude })


### PR DESCRIPTION
Apparentally the function glob.sync does not recognize Windows paths (ie C:\Users\...\NuxtProject\store). If we replace back slashes with forward slashes on Windows it should work.