### PR TITLE
add modules indexes detection

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -11,8 +11,13 @@ function addModule (storeModule, namespaces, alias) {
   const namespace = namespaces.shift()
 
   storeModule.modules[namespace] = storeModule.modules[namespace] || {}
-  storeModule.modules[namespace].alias = storeModule.modules[namespace].alias || alias
   storeModule.modules[namespace].modules = storeModule.modules[namespace].modules || {}
+
+  const isFinalNamespace = namespaces.length === 0
+  if (isFinalNamespace) {
+    storeModule.modules[namespace].alias = alias
+    return
+  }
 
   return addModule(storeModule.modules[namespace], namespaces, alias)
 }
@@ -24,7 +29,7 @@ function makeModulesString (modules) {
   return '{' + entries.map(([key, val]) => {
     return `
       ${key}: {
-        ...${val.alias},
+        ${val.alias ? `...${val.alias},` : ''}
         namespaced: true,
         modules: ${makeModulesString(val.modules)}
       }
@@ -58,6 +63,10 @@ export const register = {
         // Modules
         const namespace = path.replace(/\.(js|mjs|ts)$/, '')
         const namespaces = namespace.split('/')
+        const isNamespaceIndexFile = namespaces[namespaces.length - 1] === 'index'
+        if (isNamespaceIndexFile) {
+          namespaces.pop()
+        }
         addModule(store, namespaces, alias)
       }
     })

--- a/tests/module.nuxt.test.ts
+++ b/tests/module.nuxt.test.ts
@@ -6,33 +6,29 @@ describe('vuex', () => {
     const store = useNuxtApp().$store
 
     expect(Object.keys(store._actions)).toEqual([
-      'auth/one',
-      'auth/two',
-      'merchant/one',
-      'merchant/two',
-      'merchant/orders/one',
-      'merchant/orders/two',
-      'merchant/catalog/one',
-      'merchant/catalog/two',
-      'merchant/catalog/bundles/one',
-      'merchant/catalog/bundles/two',
-      'merchant/catalog/categories/one',
-      'merchant/catalog/categories/two',
+      'auth/authOne',
+      'auth/authTwo',
+      'merchant/orders/merchantOrdersOne',
+      'merchant/orders/merchantOrdersTwo',
+      'merchant/catalog/merchantCatalogIndexOne',
+      'merchant/catalog/merchantCatalogIndexTwo',
+      'merchant/catalog/bundles/merchantCatalogBundlesOne',
+      'merchant/catalog/bundles/merchantCatalogBundlesTwo',
+      'merchant/catalog/categories/merchantCatalogCategoriesOne',
+      'merchant/catalog/categories/merchantCatalogCategoriesTwo',
     ])
 
     expect(Object.keys(store._mutations)).toEqual([
-      'auth/ONE',
-      'auth/TWO',
-      'merchant/ONE',
-      'merchant/TWO',
-      'merchant/orders/ONE',
-      'merchant/orders/TWO',
-      'merchant/catalog/ONE',
-      'merchant/catalog/TWO',
-      'merchant/catalog/bundles/ONE',
-      'merchant/catalog/bundles/TWO',
-      'merchant/catalog/categories/ONE',
-      'merchant/catalog/categories/TWO',
+      'auth/authONE',
+      'auth/authTWO',
+      'merchant/orders/merchantOrdersONE',
+      'merchant/orders/merchantOrdersTWO',
+      'merchant/catalog/merchantCatalogIndexONE',
+      'merchant/catalog/merchantCatalogIndexTWO',
+      'merchant/catalog/bundles/merchantCatalogBundlesONE',
+      'merchant/catalog/bundles/merchantCatalogBundlesTWO',
+      'merchant/catalog/categories/merchantCatalogCategoriesONE',
+      'merchant/catalog/categories/merchantCatalogCategoriesTWO',
     ])
   })
 })

--- a/tests/playground/store/auth.js
+++ b/tests/playground/store/auth.js
@@ -4,21 +4,21 @@ export const state = () => ({
 })
 
 export const actions = {
-  async one ({ commit }) {
-    commit('ONE')
+  async authOne ({ commit }) {
+    commit('authONE')
   },
 
-  async two ({ commit }) {
-    commit('TWO')
+  async authTwo ({ commit }) {
+    commit('authTWO')
   },
 }
 
 export const mutations = {
-  ONE (state) {
+  authONE (state) {
     state.one = true
   },
 
-  TWO (state) {
+  authTWO (state) {
     state.two = true
   },
 }

--- a/tests/playground/store/merchant/catalog/bundles.js
+++ b/tests/playground/store/merchant/catalog/bundles.js
@@ -4,21 +4,21 @@ export const state = () => ({
 })
 
 export const actions = {
-  async one ({ commit }) {
-    commit('ONE')
+  async merchantCatalogBundlesOne ({ commit }) {
+    commit('merchantCatalogBundlesONE')
   },
 
-  async two ({ commit }) {
-    commit('TWO')
+  async merchantCatalogBundlesTwo ({ commit }) {
+    commit('merchantCatalogBundlesTWO')
   },
 }
 
 export const mutations = {
-  ONE (state) {
+  merchantCatalogBundlesONE (state) {
     state.one = true
   },
 
-  TWO (state) {
+  merchantCatalogBundlesTWO (state) {
     state.two = true
   },
 }

--- a/tests/playground/store/merchant/catalog/categories.js
+++ b/tests/playground/store/merchant/catalog/categories.js
@@ -4,21 +4,21 @@ export const state = () => ({
 })
 
 export const actions = {
-  async one ({ commit }) {
-    commit('ONE')
+  async merchantCatalogCategoriesOne ({ commit }) {
+    commit('merchantCatalogCategoriesONE')
   },
 
-  async two ({ commit }) {
-    commit('TWO')
+  async merchantCatalogCategoriesTwo ({ commit }) {
+    commit('merchantCatalogCategoriesTWO')
   },
 }
 
 export const mutations = {
-  ONE (state) {
+  merchantCatalogCategoriesONE (state) {
     state.one = true
   },
 
-  TWO (state) {
+  merchantCatalogCategoriesTWO (state) {
     state.two = true
   },
 }

--- a/tests/playground/store/merchant/catalog/index.js
+++ b/tests/playground/store/merchant/catalog/index.js
@@ -1,0 +1,24 @@
+export const state = () => ({
+  one: false,
+  two: false,
+})
+
+export const actions = {
+  async merchantCatalogIndexOne ({ commit }) {
+    commit('merchantCatalogIndexONE')
+  },
+
+  async merchantCatalogIndexTwo ({ commit }) {
+    commit('merchantCatalogIndexTWO')
+  },
+}
+
+export const mutations = {
+  merchantCatalogIndexONE (state) {
+    state.one = true
+  },
+
+  merchantCatalogIndexTWO (state) {
+    state.two = true
+  },
+}

--- a/tests/playground/store/merchant/orders.js
+++ b/tests/playground/store/merchant/orders.js
@@ -4,21 +4,21 @@ export const state = () => ({
 })
 
 export const actions = {
-  async one ({ commit }) {
-    commit('ONE')
+  async merchantOrdersOne ({ commit }) {
+    commit('merchantOrdersONE')
   },
 
-  async two ({ commit }) {
+  async merchantOrdersTwo ({ commit }) {
     commit('TWO')
   },
 }
 
 export const mutations = {
-  ONE (state) {
+  merchantOrdersONE (state) {
     state.one = true
   },
 
-  TWO (state) {
+  merchantOrdersTWO (state) {
     state.two = true
   },
 }


### PR DESCRIPTION
Thanks for this package, it is very useful. I suggest to make a small improvement.
I tried to use this package to migrate my Vuex store from Nuxt 2 project to Nuxt 3 project and found that this package doesn't really "read all your store folders **the same way** Nuxt 2 does". That's because Nuxt 2 can detect index files not only in the root of the store, but also in subfolders. This package sets the first detected file in a subfolder as an index for a module, and adds the actual "index" file as a regular submodule. So I added the "subfolder index discovery" feature to this package and now my Vuex store works correctly in Nuxt 3, just as it did in Nuxt 2.

Illustration (as it was on the left and as it is now on the right.):
<img width="1374" alt="Index illustration" src="https://github.com/vedmant/nuxt3-vuex/assets/11351889/051008aa-1e20-4d7c-a6f9-b229b845a6d7">

_Note that if merge my improvement in its current form, a major version of the package will need to be released._