### PR TITLE
feat: Adds support to load stores that are created with a single default export

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -29,7 +29,7 @@ function makeModulesString (modules) {
   return '{' + entries.map(([key, val]) => {
     return `
       ${key}: {
-        ${val.alias ? `...${val.alias},` : ''}
+        ${val.alias ? `...${val.alias}.default ?? ${val.alias},` : ''}
         namespaced: true,
         modules: ${makeModulesString(val.modules)}
       }

--- a/tests/module.nuxt.test.ts
+++ b/tests/module.nuxt.test.ts
@@ -8,6 +8,7 @@ describe('vuex', () => {
     expect(Object.keys(store._actions)).toEqual([
       'auth/authOne',
       'auth/authTwo',
+      'pages/pageOne',
       'merchant/orders/merchantOrdersOne',
       'merchant/orders/merchantOrdersTwo',
       'merchant/catalog/merchantCatalogIndexOne',
@@ -21,6 +22,7 @@ describe('vuex', () => {
     expect(Object.keys(store._mutations)).toEqual([
       'auth/authONE',
       'auth/authTWO',
+      'pages/pageONE',
       'merchant/orders/merchantOrdersONE',
       'merchant/orders/merchantOrdersTWO',
       'merchant/catalog/merchantCatalogIndexONE',

--- a/tests/playground/store/pages.js
+++ b/tests/playground/store/pages.js
@@ -1,0 +1,16 @@
+export default {
+  state: () => ({
+    one: false,
+    two: false,
+  }),
+  actions: {
+    async pageOne ({ commit }) {
+      commit('pageONE')
+    },
+  },
+  mutations: {
+    pageONE (state) {
+      state.one = true
+    },
+  },
+}


### PR DESCRIPTION
Issue: nuxt2 could automatically load stores defined as a single export

```
export default {
  state: () => ({
    one: false,
    two: false,
  }),
  actions: {
    async pageOne ({ commit }) {
      commit('pageONE')
    },
  },
  mutations: {
    pageONE (state) {
      state.one = true
    },
  },
}
```

A little related to issue https://github.com/vedmant/nuxt3-vuex/issues/14

___

I added 1 test to exemplify